### PR TITLE
Fix allowing bus routes to have only one section

### DIFF
--- a/SOHModel/Bus/Model/BusDriver.cs
+++ b/SOHModel/Bus/Model/BusDriver.cs
@@ -139,7 +139,7 @@ public class BusDriver : AbstractAgent, IBusSteeringCapable
         else
             throw new ArgumentException($"No bus route provided by {nameof(BusRouteLayer)}");
 
-        if (BusRoute.Count() < 2)
+        if (BusRoute.Count() < 1)
             throw new ArgumentException("Bus route requires at least two stops");
 
         if (ReversedRoute)

--- a/SOHTests/BusModelTests/BusDriverTests.cs
+++ b/SOHTests/BusModelTests/BusDriverTests.cs
@@ -265,4 +265,60 @@ public class BusDriverTests : IClassFixture<BusRouteLayerFixture>
         Assert.True(driver.GoalReached);
         Assert.NotEqual(source, driver.Position);
     }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(0, true)]
+    public void TestRouteNeedsAtLeastOneSection(int remainingStations, bool shouldFail)
+    {
+
+        BusDriver busDriver = new(_layer, (_, _) => { })
+        {
+            Line = "113",
+        };
+
+        // run Tick once, to setup initial values from the _layer
+        busDriver.Tick();
+
+        // preconditions: BusRoute is not null and has at least one entry
+        Assert.True(busDriver.BusRoute != null && busDriver.BusRoute.Entries != null && busDriver.BusRoute.Entries.Count > 0);
+
+        // copy the original BusRoute, to restore it later
+        List<BusRouteEntry> busRouteEntriesCopy = CopyRouteEntries(busDriver.BusRoute.Entries);
+
+        
+        busDriver.BusRoute.Entries.RemoveRange(0, busDriver.BusRoute.Entries.Count - remainingStations);
+        if (shouldFail) busDriver.BusRoute = null;
+
+        Exception exception = null;
+        try
+        {
+            busDriver.Tick();
+        }
+        catch (Exception e)
+        {
+            exception = e;
+        }
+        
+        if (!shouldFail) {
+            Assert.Null(exception);
+        } else {
+            Assert.NotNull(exception);
+            Assert.Equal(typeof(ArgumentException), exception.GetType());
+        }
+
+        // restore the original BusRoute
+        busDriver.BusRoute.Entries = busRouteEntriesCopy;
+    }
+
+
+    private List<BusRouteEntry> CopyRouteEntries(List<BusRouteEntry> routeEntries)
+    {
+        List<BusRouteEntry> copy = new();
+        foreach (BusRouteEntry entry in routeEntries)
+        {
+            copy.Add(new BusRouteEntry(entry.From, entry.To, entry.Minutes));
+        }
+        return copy;
+    }
 }


### PR DESCRIPTION
## Summary
- Allow BusRoute in BusDriver to have one or more BusRouteEntries (before it was two or more)
- Implemented a Test, to validate the functionality