### PR TITLE
Add PropertyDescriptions for passenger metrics in BusDriver class

### DIFF
--- a/SOHModel/Bus/Model/BusDriver.cs
+++ b/SOHModel/Bus/Model/BusDriver.cs
@@ -50,6 +50,10 @@ public class BusDriver : AbstractAgent, IBusSteeringCapable
     [PropertyDescription(Name = "waitingInSeconds")]
     public int MinimumBoardingTimeInSeconds { get; set; }
 
+    [PropertyDescription] public int PassengerAmount => Bus.Passengers.Count;
+
+    [PropertyDescription] public int PassengerCapacity => Bus.PassengerCapacity;
+
     /// <summary>
     ///     The route will be proceeded in the opposite direction.
     /// </summary>


### PR DESCRIPTION
This PR adds the two passenger metrics, `PassengerAmount` and `PassengerCapacity`, as `PropertyDescription`s to the `BusDriver.cs` class. The metrics can be accessed within the `outputConfiguration` of the configuration files for better tracking and reporting of passenger data.