### PR TITLE
fix: logger env file usage

### DIFF
--- a/SOHTruckFuelAlternativeBox/.env.example
+++ b/SOHTruckFuelAlternativeBox/.env.example
@@ -1,0 +1,11 @@
+# where to read the MARS config from 
+MARS_CONFIG_PATH=config.json
+
+# connection parameters for the logger DB (can be the same as the main output database)
+CONTAINER_NAME=mars_postgis
+DB_NAME=soh_truck_fuel_alternative
+DB_USER=mars_soh_logistics
+DB_PASSWORD=admin
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_TABLE=semitruckdriver

--- a/SOHTruckFuelAlternativeBox/README.md
+++ b/SOHTruckFuelAlternativeBox/README.md
@@ -163,7 +163,9 @@ docker exec -e PGPASSWORD=admin mars_postgis \
   psql -U mars_soh_logistics -c "CREATE DATABASE soh_truck_fuel_alternative;"
 ```
 
-Connection parameters are read from `SOHTruckFuelAlternativeBox/.env` (or override via `MARS_CONFIG_PATH`).
+Connection parameters used for logging are read from `SOHTruckFuelAlternativeBox/.env`.
+This can be set to the same values as found in the respective `config.json` file.
+See `SOHTruckFuelAlternativeBox/.env.example` for more details.
 
 ### 2. Road network file
 

--- a/SOHTruckFuelAlternativeBox/SOHTruckFuelAlternativeBox.csproj
+++ b/SOHTruckFuelAlternativeBox/SOHTruckFuelAlternativeBox.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include=".env">
+        <None Include=".env" Condition="Exists('.env')">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         <Content Include="config.json">


### PR DESCRIPTION
the build file expected a `.env` file to be present, even though it's only used for runtime execution, not as a build input. Nevertheless, since env files are typically git ignored to not leak any secrets, it has to be made clear to the compiler that it's ok if it doesn't find such a file.

Additionally, an `.env.example` has been added, also making it clearer to developers who want to make use the custom DB logger.